### PR TITLE
Use the regex module when tokenizing, which makes it possible to matc…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ networkx
 clint
 pytest
 click
+regex

--- a/textplot/utils.py
+++ b/textplot/utils.py
@@ -1,6 +1,6 @@
 
 
-import re
+import regex
 import numpy as np
 import functools
 
@@ -22,7 +22,7 @@ def tokenize(text):
     """
 
     stem = PorterStemmer().stem
-    tokens = re.finditer('[a-z]+', text.lower())
+    tokens = regex.finditer('\p{L}+', text.lower())
 
     for offset, match in enumerate(tokens):
 


### PR DESCRIPTION
…h all word-y, non-digit characters, regardless of encoding.